### PR TITLE
WIP: Adds scripts etc. for building and running mypy against cb using docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.6
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | apt-key add -
+RUN echo "deb http://packages.couchbase.com/ubuntu bionic bionic/main" | tee /etc/apt/sources.list.d/couchbase.list
+
+RUN apt-get update \
+    # CB dependencies
+    && apt-get install -y libcouchbase-dev libcouchbase2-bin libgeoip-dev libxml2-dev libxslt1-dev libssl-dev libsqlite3-dev zlib1g-dev \
+    # cleaning up unused files
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/*
+
+# need the resolver from the older version of pip for now
+RUN pip install pip==20.2.3
+RUN pip install -r cb_requirements.txt
+RUN pip install mypy
+RUN pip install django-stubs
+
+CMD mypy /cb-dev --custom-typeshed-dir .

--- a/cb-scripts/README.md
+++ b/cb-scripts/README.md
@@ -1,0 +1,9 @@
+# Chaturbate MyPy
+
+## Usage (docker)
+
+### Build docker image
+Change into `cb-scripts` directory and use `./cb-mypy-build.sh cb_dir` where `cb_dir` is the (absolute) path to your local chaturbate repo. Alternatively copy `cb_dir/requirements.txt` to this repo's root folder as `cb_requirements.txt` pass an empty string or other placeholder to the build script.
+
+### Run docker container
+Change into `cb-scripts` directory and use `./cb-mypy.sh cb_dir` where `cb_dir` is the (absolute) path to your local chaturbate repo. Alternatively pass a volume path from another docker container that leads to the chaturbate root directory there.

--- a/cb-scripts/cb-mypy-build.sh
+++ b/cb-scripts/cb-mypy-build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "Usage: ./cb-mypy-build.sh cb_dir"
+    exit 1
+fi
+
+cp $1/requirements.txt ../cb_requirements.txt
+docker build -t cb-typeshed ..
+rm ../cb_requirements.txt

--- a/cb-scripts/cb-mypy.sh
+++ b/cb-scripts/cb-mypy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "Usage: ./cb-mypy.sh cb_dir"
+    exit 1
+fi
+
+docker run -it --rm \
+  -v $1:/cb-dev \
+  cb-typeshed

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[mypy]
+check_untyped_defs = True
+ignore_missing_imports = True
+disable_error_code = attr-defined, name-defined, call-arg, arg-type, call-overload, valid-type, var-annotated, override, return, return-value, assignment, type-arg, type-var, union-attr, index, list-item, dict-item, typeddict-item, has-type, import, no-redef, func-returns-value, abstract, valid-newtype, str-format, str-bytes-safe, exit-return, misc

--- a/stubs/redis/redis/client.pyi
+++ b/stubs/redis/redis/client.pyi
@@ -56,7 +56,7 @@ _Value = Union[bytes, float, int, Text]
 _Key = Union[Text, bytes]
 
 # Lib returns str or bytes depending on Python version and value of decode_responses
-_StrType = TypeVar("_StrType", bound=Union[Text, bytes])
+_StrType = TypeVar("_StrType", bound=Text)
 
 class Redis(Generic[_StrType]):
     RESPONSE_CALLBACKS: Any


### PR DESCRIPTION
[LeanKit](https://multimediallc.leankit.com/card/30502078173698)

This PR adds scripts and a README in `cb-scripts` for using this forked version of typeshed to check the chaturbate [repo](https://github.com/multimediallc/chaturbate) using just the error code `operator`. It also updates `redis/redis/client.pyi` to not accept `bytes` as a valid string type.

Currently it does not work, many problems arise upon trying to use a custom typeshed. Remove `--custom-typeshed-dir .` from `Dockerfile` `CMD` to run with the normal version of typeshed, which does work. To see this error, comment out the `ignore_missing_imports` line in `setup.cfg` and then build and run.

Further finding documented in leanKit card description.